### PR TITLE
Fixes #INTELLIJ-28 to use current IntelliJ 2018.3 classes in plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,11 +121,11 @@ formatSource {
 
 intellij {
 	plugins "CSS", "DatabaseTools", "gradle", "Groovy", "java-i18n", "JavaEE", "JavaScriptLanguage", "jsp", "junit", "maven", "PersistenceSupport", "properties", "sass", "terminal"
-	version "IU-2018.2.2"
+	version "IU-2018.3.2"
 }
 
 patchPluginXml {
-	sinceBuild "172"
+	sinceBuild "183"
 	untilBuild ""
 }
 

--- a/src/main/java/com/liferay/ide/idea/terminal/GogoShellLocalRunner.java
+++ b/src/main/java/com/liferay/ide/idea/terminal/GogoShellLocalRunner.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.JBTerminalWidget;
 import com.intellij.util.EnvironmentUtil;
 
 import com.liferay.ide.idea.util.LiferayWorkspaceUtil;
@@ -34,7 +35,6 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.plugins.terminal.JBTabbedTerminalWidget;
 import org.jetbrains.plugins.terminal.LocalTerminalDirectRunner;
 import org.jetbrains.plugins.terminal.TerminalProjectOptionsProvider;
 
@@ -48,13 +48,13 @@ public class GogoShellLocalRunner extends LocalTerminalDirectRunner {
 	}
 
 	@Override
-	public JBTabbedTerminalWidget createTerminalWidget(Disposable parent) {
-		_terminalWidget = super.createTerminalWidget(parent);
+	public JBTerminalWidget createTerminalWidget(Disposable parent, @Nullable VirtualFile currentWorkingDirectory) {
+		_terminalWidget = super.createTerminalWidget(parent, currentWorkingDirectory);
 
 		return _terminalWidget;
 	}
 
-	public JBTabbedTerminalWidget getTerminalWidget() {
+	public JBTerminalWidget getTerminalWidget() {
 		return _terminalWidget;
 	}
 
@@ -127,6 +127,6 @@ public class GogoShellLocalRunner extends LocalTerminalDirectRunner {
 		return port;
 	}
 
-	private JBTabbedTerminalWidget _terminalWidget;
+	private JBTerminalWidget _terminalWidget;
 
 }

--- a/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypeStep.java
+++ b/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypeStep.java
@@ -17,7 +17,6 @@ package com.liferay.ide.idea.ui.modules;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleProvider;
 import com.intellij.framework.addSupport.FrameworkSupportInModuleProvider.FrameworkDependency;
 import com.intellij.ide.projectWizard.ProjectCategory;
-import com.intellij.ide.projectWizard.ProjectCategoryUsagesCollector;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.ide.util.frameworkSupport.FrameworkRole;
 import com.intellij.ide.util.frameworkSupport.FrameworkSupportUtil;
@@ -390,12 +389,6 @@ public class LiferayProjectTypeStep extends ModuleWizardStep implements Settings
 			if (!ok) {
 				throw new CommitStepException(null);
 			}
-		}
-
-		TemplatesGroup group = _getSelectedGroup();
-
-		if (group != null) {
-			ProjectCategoryUsagesCollector.projectTypeUsed(group.getId());
 		}
 	}
 


### PR DESCRIPTION
Fixes issue [INTELLIJ-28](https://issues.liferay.com/browse/INTELLIJ-28) which indeed fails to createw Liferay Module using current IntelliJ 2018.3.