### PR TITLE
LPD-87370 records to changelog

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,9 @@
 	<h3>3.1.1</h3>
 	<ul>
 		<li>LPD-80819 IntelliJ Plugin startup error for LiferayWebFacetPostStartupActivity</li>
-		<li>LPD-83433 SymbolicIdAlreadyExistsException when creating a new Liferay Gradle Workspace</li>
+		<li>LPD-83433 SymbolicIdAlreadyExistsException for module entity when creating a new Liferay Gradle Workspace</li>
+		<li>LPD-86908 Update embedded Blade to version 8.0.1 SNAPSHOT</li>
+		<li>LPD-87370 SymbolicIdAlreadyExistsException for SDK entity when creating a new Liferay Gradle Workspace</li>
 	</ul>
 
 	<h3>3.1.0</h3>


### PR DESCRIPTION
## Summary
- Adds changelog entries for LPD-86908 and LPD-87370 to the 3.1.1 section in plugin.xml
- Disambiguates LPD-83433 and LPD-87370 descriptions (both addressed SymbolicIdAlreadyExistsException but for different entity types)

## Test plan
- [ ] Verify plugin.xml is well-formed XML
- [ ] Verify changelog entries match ticket descriptions